### PR TITLE
vampirism.co playtest

### DIFF
--- a/src/main/java/net/grid/vampiresdelight/common/VDConfiguration.java
+++ b/src/main/java/net/grid/vampiresdelight/common/VDConfiguration.java
@@ -30,32 +30,35 @@ public class VDConfiguration {
     static {
         // COMMON
         ForgeConfigSpec.Builder COMMON_BUILDER = new ForgeConfigSpec.Builder();
+        COMMON_BUILDER.comment("Common settings").push("common");
 
         COMMON_BUILDER.comment("Village").push(CATEGORY_VILLAGE);
         FARMERS_BUY_GARLIC = COMMON_BUILDER.comment("Should Farmers buy garlic? (May reduce chances of other trades appearing)")
                 .define("farmersBuyGarlic", true);
         WANDERING_TRADER_SELLS_VAMPIRISM_ITEMS = COMMON_BUILDER.comment("Should the Wandering Trader sell some of vampirism's and this mod's items? (Including seeds and some blocks)")
                 .define("wanderingTraderSellsVampirismItems", true);
+        COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("Recipe book").push(CATEGORY_RECIPE_BOOK);
         ENABLE_RECIPE_BOOK_BREWING_BARREL = COMMON_BUILDER.comment("Should the Brewing Barrel have a Recipe Book available on its interface?")
                 .define("enableRecipeBookBrewingBarrel", true);
+        COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("Effects").push(CATEGORY_EFFECTS);
         ARMOR_DISSOLVES_FULLY = COMMON_BUILDER.comment("Should 'weak' armor such as leather and chain dissolve fully because of Clothes Dissolving effect?")
                 .define("armorDissolvesFully", true);
+        COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("World generation").push(CATEGORY_WORLD);
         GENERATE_VD_CHEST_LOOT = COMMON_BUILDER.comment("Should this mod add some of its items as extra chest loot across Minecraft and Vampirism structures?")
                 .define("generateVDChestLoot", true);
-
         COMMON_BUILDER.pop();
+
         COMMON_CONFIG = COMMON_BUILDER.build();
 
 
         // CLIENT
         ForgeConfigSpec.Builder CLIENT_BUILDER = new ForgeConfigSpec.Builder();
-
         CLIENT_BUILDER.comment("Client settings").push(CATEGORY_CLIENT);
 
         COLORED_TOOLTIPS = CLIENT_BUILDER.comment("Should the mod change the color of tooltips?")

--- a/src/main/java/net/grid/vampiresdelight/common/VDConfiguration.java
+++ b/src/main/java/net/grid/vampiresdelight/common/VDConfiguration.java
@@ -15,6 +15,7 @@ public class VDConfiguration {
     public static ForgeConfigSpec.BooleanValue ENABLE_RECIPE_BOOK_BREWING_BARREL;
 
     public static final String CATEGORY_EFFECTS = "effects";
+    public static ForgeConfigSpec.BooleanValue REPLACE_WEIRD_JELLY_SUNSCREEN_WITH_JUMPBOOST;
     public static ForgeConfigSpec.BooleanValue ARMOR_DISSOLVES_FULLY;
 
     public static final String CATEGORY_WORLD = "world";
@@ -45,6 +46,8 @@ public class VDConfiguration {
         COMMON_BUILDER.pop();
 
         COMMON_BUILDER.comment("Effects").push(CATEGORY_EFFECTS);
+        REPLACE_WEIRD_JELLY_SUNSCREEN_WITH_JUMPBOOST = COMMON_BUILDER.comment("Should the weird jelly sunscreen effect be replaced with Jump Boost?")
+                .define("replaceWeirdJellySunscreenWithJumpboost", false);
         ARMOR_DISSOLVES_FULLY = COMMON_BUILDER.comment("Should 'weak' armor such as leather and chain dissolve fully because of Clothes Dissolving effect?")
                 .define("armorDissolvesFully", true);
         COMMON_BUILDER.pop();

--- a/src/main/java/net/grid/vampiresdelight/common/VDFoodValues.java
+++ b/src/main/java/net/grid/vampiresdelight/common/VDFoodValues.java
@@ -101,7 +101,7 @@ public class VDFoodValues {
             .nutrition(7).saturationMod(0.6f).fast()
             .effect(() -> new MobEffectInstance(MobEffects.MOVEMENT_SPEED, BRIEF_DURATION), 1.0F).build();
     public static final FoodProperties PURE_SORBET = (new FoodProperties.Builder())
-            .nutrition(16).saturationMod(0.8f).fast().alwaysEat()
+            .nutrition(10).saturationMod(0.8f).fast().alwaysEat()
             .effect(() -> new MobEffectInstance(VDEffects.FOG_VISION.get(), MEDIUM_DURATION), 1.0F).build();
     public static final FoodProperties TRICOLOR_DANGO = (new FoodProperties.Builder())
             .nutrition(13).saturationMod(1.4f).fast().build();

--- a/src/main/java/net/grid/vampiresdelight/common/VDFoodValues.java
+++ b/src/main/java/net/grid/vampiresdelight/common/VDFoodValues.java
@@ -150,5 +150,11 @@ public class VDFoodValues {
     // Feast Portions
     public static final FoodProperties WEIRD_JELLY = (new FoodProperties.Builder())
             .nutrition(7).saturationMod(0.8f).fast().alwaysEat()
-            .effect(() -> new MobEffectInstance(de.teamlapen.vampirism.core.ModEffects.SUNSCREEN.get(), BRIEF_DURATION), 1.0F).build();
+            .effect(() -> {
+                if (VDConfiguration.REPLACE_WEIRD_JELLY_SUNSCREEN_WITH_JUMPBOOST.get()) {
+                    return new MobEffectInstance(MobEffects.JUMP, BRIEF_DURATION);
+                } else {
+                    return new MobEffectInstance(de.teamlapen.vampirism.core.ModEffects.SUNSCREEN.get(), BRIEF_DURATION);
+                }
+            }, 1.0F).build();
 }


### PR DESCRIPTION
# fix config indentation
![image](https://github.com/TheGridExpert/VampiresDelight/assets/42828197/08429d61-fca9-415d-9ef0-807602a94e36)

# add config option for balancing sunscreen
Default is sunscreen. When changed, weird jelly will give jump boost instead

# balance pure sorbet
16 saturation with pure blood 5 would be fine, but any pure blood can be easy to get. However we don't want the recipe to be changed to pure blood 5 in order to not make it rarer. So, saturation 16 -> 10?